### PR TITLE
Fix Slack token validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project should be documented in this file.
 
-### v0.0.4-dev
+### v0.0.4
 
 - Fix the Slack token validation not accepting some tokens (#57)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project should be documented in this file.
 
+### v0.0.4-dev
+
+- Fix the Slack token validation not accepting some tokens (#57)
+
 ### v0.0.3
 
 - Fix the _wrong catch_ for `3xx` status codes to be ignored in Directory Bruteforce (#56)

--- a/pkg/matchers/patterns.go
+++ b/pkg/matchers/patterns.go
@@ -1,7 +1,7 @@
 package matchers
 
 const (
-	PatternToken     = `^(xox[p|b|o|a]-\d{10,12}-\d{12}-\w+)|(\d{9}:[a-zA-Z0-9_-]{35})|([MN][A-Za-z\d]{23}\.[\w-]{6}\.[\w-]{27})$`
+	PatternToken     = `^(xox[p|b|o|a]-\d{10,12}-\d{12,13}-\w+)|(\d{9}:[a-zA-Z0-9_-]{35})|([MN][A-Za-z\d]{23}\.[\w-]{6}\.[\w-]{27})$`
 	PatternChannel   = `^([A-Z0-9]{9,18})$`
 	PatternColor     = `^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})|(\d{1,8})$`
 	PatternLogformat = `\$(remote_(addr|user)|request_(method|uri|protocol)|http_(referer|user_agent))`


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first!**

_(Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request)._

### Summary

This fixes #57 by allowing the third part of the Slack token to be 12-13 digits instead of just 12 digits. I generated a Slack bot token several times and received several tokens which all contain 13 digits instead of the 12 digits expected by the json here. I opened the PR because I like teler and wanted to get it working tonight anyways and thought I would contribute.

_Explains the information and/ motivation for making this changes..._

### Proposed of changes

This PR fixes/implements the following **bugs/features**:

- [BUG] Validation does not accept valid Slack tokens

### How has this been tested?

Proof:

I compiled my own code using `make build` and it now posts to Slack as expected.

![https://i.gyazo.com/bd48eb1b78b6006882cfb34282184059.png](https://i.gyazo.com/bd48eb1b78b6006882cfb34282184059.png)

I also double checked that the regex still works for 12 digits

![https://i.gyazo.com/f69c80d25dba086a284d973e3cadec42.png](https://i.gyazo.com/f69c80d25dba086a284d973e3cadec42.png)

### Closing issues

Fixes #57 

### Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] I have followed the guidelines in our [CONTRIBUTING.md](https://github.com/kitabisa/teler/blob/development/.github/CONTRIBUTING.md) document.
- [ ] I have written new tests for my changes.
  - [ ] My changes successfully ran and pass tests locally.