### PR TITLE
make -v option work

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: docker/setup-qemu-action@v1.0.1
       
       - name: "Set up Docker Buildx"
-        uses: docker/setup-buildx-action@v1.1.0
+        uses: docker/setup-buildx-action@v1.1.1
       
       - name: "Login to DockerHub"
         uses: docker/login-action@v1.8.0

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: docker/setup-qemu-action@v1.0.1
       
       - name: "Set up Docker Buildx"
-        uses: docker/setup-buildx-action@v1.0.4
+        uses: docker/setup-buildx-action@v1.1.0
       
       - name: "Login to DockerHub"
         uses: docker/login-action@v1.8.0

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,6 @@
 SHELL         = /bin/bash
 APP_NAME      = teler
 VERSION       = $(shell git describe --always --tags)
-GIT_COMMIT    = $(shell git rev-parse HEAD)
-GIT_DIRTY     = $(shell test -n "`git status --porcelain`" && echo "+CHANGES" || true)
-BUILD_DATE    = $(shell date '+%Y-%m-%d-%H:%M:%S')
 SQUAD         = infosec
 
 default: help
@@ -27,7 +24,7 @@ help:
 build:
 	@echo "Building ${APP_NAME} ${VERSION}"
 	@echo "GOPATH=${GOPATH}"
-	go build -ldflags "-w -X github.com/kitabisa/teler/version.GitCommit=${GIT_COMMIT}${GIT_DIRTY} -X github.com/kitabisa/teler/version.Version=${VERSION} -X github.com/kitabisa/teler/version.Environment=${ENVIRONMENT} -X github.com/kitabisa/teler/version.BuildDate=${BUILD_DATE}" -o ./bin/${APP_NAME} ./cmd/${APP_NAME}
+	go build -ldflags "-s -w  -X ktbs.dev/teler/versioninfo.Version=${VERSION}" -o ./bin/${APP_NAME} ./cmd/${APP_NAME}
 
 run: build
 	@echo "Running ${APP_NAME} ${VERSION}"

--- a/internal/runner/constants.go
+++ b/internal/runner/constants.go
@@ -1,15 +1,16 @@
 package runner
 
-const (
+import "ktbs.dev/teler/versioninfo"
+
+var (
 	email       = "infosec@kitabisa.com"
-	version     = "1.0.1"
 	development = false
 	banner      = `
 	  __      __       
 	 / /____ / /__ ____
 	/ __/ -_) / -_) __/
 	\__/\__/_/\__/_/   
-	                v` + version
+	                ` + versioninfo.Version
 
 	usage = `  [buffers] | teler [options]
   teler -c [...] [options]`

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -19,6 +19,7 @@ import (
 	"ktbs.dev/teler/pkg/errors"
 	"ktbs.dev/teler/pkg/metrics"
 	"ktbs.dev/teler/pkg/teler"
+	"ktbs.dev/teler/versioninfo"
 )
 
 func removeLBR(s string) string {
@@ -91,7 +92,7 @@ func New(options *common.Options) {
 						}
 					}
 
-					alert.New(options, version, obj)
+					alert.New(options, versioninfo.Version, obj)
 				}
 			}
 		}()

--- a/internal/runner/version.go
+++ b/internal/runner/version.go
@@ -3,9 +3,10 @@ package runner
 import (
 	"fmt"
 	"os"
+	"ktbs.dev/teler/versioninfo"
 )
 
 func showVersion() {
-	fmt.Printf("teler %s\n", version)
+	fmt.Printf("teler %s\n", versioninfo.Version)
 	os.Exit(2)
 }

--- a/versioninfo/versioninfo.go
+++ b/versioninfo/versioninfo.go
@@ -1,0 +1,3 @@
+package versioninfo
+
+var Version = "unknown"


### PR DESCRIPTION
### Proposed of changes

This PR fixes #94 

Hi all: 
1. we use [-ldflags "-X  importpath.name=value"](https://golang.org/cmd/link/)  option to modify the value of the Version, and then when we type `teler -v`, the program just print the version we passed in, but I can't find a suitable way to modify the version variable defined in [version](https://github.com/kitabisa/teler/blob/62623bcb3d6071f8c96d816980a36906b402e659/internal/runner/constants.go#L5), so I referenced [this repository](https://github.com/juicedata/juicesync/blob/master/Makefile), and make a new directory versioninfo, define the Version varibale there.  If you find a better way to modify the [version](https://github.com/kitabisa/teler/blob/62623bcb3d6071f8c96d816980a36906b402e659/internal/runner/constants.go#L5), CORRECT ME!

2. as the [GoDoc](https://golang.org/cmd/link/) says:
```sh
 -X importpath.name=value
Set the value of the string variable in importpath named name to value.
This is only effective if the variable is declared in the source code either uninitialized
or initialized to a constant string expression. -X will not work if the initializer makes
a function call or refers to other variables.
Note that before Go 1.5 this option took two separate arguments.
```
I found there is no variables  `GitCommit`  `Environment`  `BuildDate` defined in source code, so there is no need to keep them and related variables.

3. I added `-ldflags "-s"` in the Makefile,  as the [GoDoc](https://golang.org/cmd/link/) says:
```sh
 -s  Omit the symbol table and debug information.
```
this can make binary executable file **smaller**, we DON'T need the symbol table and debug information  when delivering a binary release.

to prove this, I'm doing the following on windows10 and using git-bash
- with `-ldflags "-s"`
```sh
/d/golang/src/github.com/kisielk/teler (master)
$ make  build
Building teler v1.0.1-29-g62623bc
GOPATH=d:\golang
go build -ldflags "-s -w  -X ktbs.dev/teler/versioninfo.Version=v1.0.1-29-g62623bc" -o ./bin/teler ./cmd/teler

$ du -sh bin/teler
12M     bin/teler
```

- without `-ldflags "-s"`
```sh
 /d/golang/src/github.com/kisielk/teler (master)
$ make  build
Building teler v1.0.1-29-g62623bc
GOPATH=d:\golang
go build -ldflags "-w  -X ktbs.dev/teler/versioninfo.Version=v1.0.1-29-g62623bc" -o ./bin/teler ./cmd/teler

$ du -sh bin/teler
13M     bin/teler
```
we save **1MB** disk space!






























