### PR TITLE
Fix Docker image name in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ Simply, teler can be run with:
 If you've built teler with a Docker image:
 
 ```bash
-▶ [buffers] | docker run -i --rm -e TELER_CONFIG=/path/to/config/teler.yaml teler
+▶ [buffers] | docker run -i --rm -e TELER_CONFIG=/path/to/config/teler.yaml kitabisa/teler
 # or
-▶ docker run -i --rm -e TELER_CONFIG=/path/to/config/teler.yaml teler --input /path/to/access.log
+▶ docker run -i --rm -e TELER_CONFIG=/path/to/config/teler.yaml kitabisa/teler --input /path/to/access.log
 ```
 
 ### Flags


### PR DESCRIPTION
### Summary

See #117 

### Proposed of changes

This PR fixes Docker image name in README.

### How has this been tested?

Locally using appropriate `docker run` commands.

### Closing issues

Fixes #117 

### Checklist:

- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] I have followed the guidelines in our [CONTRIBUTING.md](https://github.com/kitabisa/teler/blob/development/.github/CONTRIBUTING.md) document.